### PR TITLE
Add minimal chat and file upload web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Agent_interface_web
+# Agent Interface Web
+
+This project provides a minimal web interface to interact with a simple conversational agent and upload files. The site runs on localhost using only Python's standard library, so no additional packages are required.
+
+## Running
+
+Use Python 3 to start the local server:
+
+```bash
+python3 app.py
+```
+
+The server listens on [http://localhost:8888](http://localhost:8888). Opening this URL in a browser shows a chat box and a file upload form.
+
+Uploaded files are stored in the `uploads/` directory.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+import http.server
+import socketserver
+import urllib.parse
+import json
+import os
+import cgi
+
+PORT = 8888
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/':
+            self.path = '/index.html'
+        return http.server.SimpleHTTPRequestHandler.do_GET(self)
+
+    def do_POST(self):
+        if self.path == '/chat':
+            length = int(self.headers.get('Content-Length'))
+            data = self.rfile.read(length).decode('utf-8')
+            params = urllib.parse.parse_qs(data)
+            message = params.get('message', [''])[0]
+            response = f"You said: {message}"
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'response': response}).encode())
+        elif self.path == '/upload':
+            ctype, pdict = cgi.parse_header(self.headers.get('Content-Type'))
+            if ctype == 'multipart/form-data':
+                form = cgi.FieldStorage(fp=self.rfile, headers=self.headers,
+                                        environ={'REQUEST_METHOD': 'POST',
+                                                 'CONTENT_TYPE': self.headers.get('Content-Type')})
+                if 'file' in form:
+                    fileitem = form['file']
+                    if fileitem.filename:
+                        fname = os.path.basename(fileitem.filename)
+                        os.makedirs('uploads', exist_ok=True)
+                        with open(os.path.join('uploads', fname), 'wb') as f:
+                            f.write(fileitem.file.read())
+            self.send_response(303)
+            self.send_header('Location', '/')
+            self.end_headers()
+        else:
+            self.send_error(404)
+
+with socketserver.TCPServer(('', PORT), Handler) as httpd:
+    print(f"Serving on http://localhost:{PORT}")
+    httpd.serve_forever()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Conversational Agent</title>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+    #chat { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: auto; }
+    .msg-user { color: blue; }
+    .msg-bot { color: green; }
+  </style>
+</head>
+<body>
+  <h1>Conversational Agent</h1>
+  <div id="chat"></div>
+  <input type="text" id="message" placeholder="Enter message" />
+  <button id="send">Send</button>
+
+  <h2>Upload File</h2>
+  <form id="uploadForm" enctype="multipart/form-data" method="post" action="/upload">
+     <input type="file" name="file" />
+     <input type="submit" value="Upload" />
+  </form>
+
+  <script>
+    const chatDiv = document.getElementById('chat');
+    const sendBtn = document.getElementById('send');
+    const msgInput = document.getElementById('message');
+
+    function addMessage(text, cls) {
+      const p = document.createElement('p');
+      p.textContent = text;
+      p.className = cls;
+      chatDiv.appendChild(p);
+      chatDiv.scrollTop = chatDiv.scrollHeight;
+    }
+
+    sendBtn.addEventListener('click', () => {
+      const msg = msgInput.value;
+      if (!msg) return;
+      addMessage('You: ' + msg, 'msg-user');
+      fetch('/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'message=' + encodeURIComponent(msg)
+      }).then(r => r.json()).then(data => {
+        addMessage('Bot: ' + data.response, 'msg-bot');
+      });
+      msgInput.value = '';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple HTTP server `app.py` using Python standard library
- create `index.html` with chat and file upload form
- document usage in `README.md`

## Testing
- `python3 app.py` (shows server start message)


------
https://chatgpt.com/codex/tasks/task_e_68779272146883219a6ac2df329e2be3